### PR TITLE
Use StringToHGlobalAnsi for UTF8Buffer

### DIFF
--- a/Raylib-cs/types/native/UTF8Buffer.cs
+++ b/Raylib-cs/types/native/UTF8Buffer.cs
@@ -13,7 +13,7 @@ namespace Raylib_cs
 
         public UTF8Buffer(string text)
         {
-            data = Marshal.StringToCoTaskMemUTF8(text);
+            this.data = Marshal.StringToHGlobalAnsi(text);
         }
 
         public unsafe sbyte* AsPointer()
@@ -23,7 +23,7 @@ namespace Raylib_cs
 
         public void Dispose()
         {
-            Marshal.FreeCoTaskMem(data);
+            Marshal.FreeHGlobal(data);
         }
     }
 


### PR DESCRIPTION
rather then StringToCoTaskMemUTF8
tested on Windows 11 (x64) & Arch Linux (x64)
should fix #172