### PR TITLE
Enable Targeting .Net 8 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 name: Build
 on:
   push:
-    branches: master
+    branches: ["master"]
   pull_request:
-    branches: "*"
+    branches: ["*"]
     paths-ignore:
       - "README.md"
       - ".github/ISSUE_TEMPLATE/**"
@@ -35,7 +35,9 @@ jobs:
       - name: setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: setup dependencies
         run: |
@@ -81,7 +83,9 @@ jobs:
       - name: setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: build projects
         run: dotnet build -c Release /p:BuildArch=${{ matrix.arch }}
@@ -114,7 +118,9 @@ jobs:
       - name: setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: build projects
         run: dotnet build -c Release /p:BuildArch=${{ matrix.arch }}
@@ -167,7 +173,9 @@ jobs:
       - name: setup dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
 
       - name: create NuGet Package
         run: dotnet pack Raylib-cs -c Release --output nuget

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartupObject>Examples.Program</StartupObject>
     <RunWorkingDirectory>$(MSBuildThisFileDirectory)</RunWorkingDirectory>

--- a/Raylib-cs.Native/Native.cs
+++ b/Raylib-cs.Native/Native.cs
@@ -1,0 +1,4 @@
+namespace Raylib_cs.Native
+{
+    internal class Native { }
+}

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="ConfigureNative">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
@@ -44,11 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content
-      Include="$(OutputPath)native/raylib/$(NativePre)raylib.$(NativeExt)"
-      Link="%(Filename)%(Extension)"
-      CopyToOutputDirectory="PreserveNewest"
-      Condition="Exists('$(OutputPath)native/raylib/$(NativePre)raylib.$(NativeExt)')" />
+    <Content Include="$(OutputPath)native/raylib/$(NativePre)raylib.$(NativeExt)" Link="%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" Condition="Exists('$(OutputPath)native/raylib/$(NativePre)raylib.$(NativeExt)')" />
 
     <CMakeArgs Include="-B $(OutputPath)native" />
     <CMakeArgs Include="-S $(BaseIntermediateOutputPath)raylib-$(TargetRaylibTag)" />
@@ -62,20 +58,11 @@
   </ItemGroup>
 
   <Target Name="ConfigureNative" Condition="$(SkipLocalBuild) != true">
-    <DownloadFile
-      SourceUrl="https://github.com/raysan5/raylib/archive/refs/tags/$(TargetRaylibTag).zip"
-      DestinationFolder="$(BaseIntermediateOutputPath)"
-      DestinationFileName="raylib.zip"
-      Condition="!Exists('$(BaseIntermediateOutputPath)raylib.zip')" />
+    <DownloadFile SourceUrl="https://github.com/raysan5/raylib/archive/refs/tags/$(TargetRaylibTag).zip" DestinationFolder="$(BaseIntermediateOutputPath)" DestinationFileName="raylib.zip" Condition="!Exists('$(BaseIntermediateOutputPath)raylib.zip')" />
 
-    <Unzip
-      SourceFiles="$(BaseIntermediateOutputPath)raylib.zip"
-      DestinationFolder="$(BaseIntermediateOutputPath)"
-      OverwriteReadOnlyFiles="true"
-      Condition="!Exists('$(BaseIntermediateOutputPath)raylib-$(TargetRaylibTag)')" />
+    <Unzip SourceFiles="$(BaseIntermediateOutputPath)raylib.zip" DestinationFolder="$(BaseIntermediateOutputPath)" OverwriteReadOnlyFiles="true" Condition="!Exists('$(BaseIntermediateOutputPath)raylib-$(TargetRaylibTag)')" />
 
-    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)"
-      Condition="!Exists('$(BaseIntermediateOutputPath)native/CMakeCache.txt')" />
+    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)" Condition="!Exists('$(BaseIntermediateOutputPath)native/CMakeCache.txt')" />
 
     <Exec Command="cmake --build $(OutputPath)native --config $(Configuration)" />
   </Target>

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -56,6 +56,7 @@
     <CMakeArgs Include="-D CMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded" />
     <CMakeArgs Include="-D CMAKE_MINIMUM_REQUIRED_VERSION=3.15" />
     <CMakeArgs Include="-D CMAKE_POLICY_DEFAULT_CMP0091=NEW" />
+    <!-- <CMakeArgs Include="-D GLFW_BUILD_WAYLAND=ON" /> -->
     <!-- <CMakeArgs Include="-D GRAPHICS=GRAPHICS_API_OPENGL_43" /> -->
   </ItemGroup>
 
@@ -64,8 +65,7 @@
 
     <Unzip SourceFiles="$(BaseIntermediateOutputPath)raylib.zip" DestinationFolder="$(BaseIntermediateOutputPath)" OverwriteReadOnlyFiles="true" Condition="!Exists('$(BaseIntermediateOutputPath)raylib-$(TargetRaylibTag)')" />
 
-    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)" Condition="!Exists('$(OutputPath)native/CMakeCache.txt')" />
-
+    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)" />
     <Exec Command="cmake --build $(OutputPath)native --config $(Configuration)" />
   </Target>
 </Project>

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="ConfigureNative">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
     <DebugType>none</DebugType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDependencyFile>False</GenerateDependencyFile>
@@ -65,7 +64,7 @@
 
     <Unzip SourceFiles="$(BaseIntermediateOutputPath)raylib.zip" DestinationFolder="$(BaseIntermediateOutputPath)" OverwriteReadOnlyFiles="true" Condition="!Exists('$(BaseIntermediateOutputPath)raylib-$(TargetRaylibTag)')" />
 
-    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)" Condition="!Exists('$(BaseIntermediateOutputPath)native/CMakeCache.txt')" />
+    <Exec Command="cmake @(CMakeArgs, ' ') $(CMakeExtraArgs)" Condition="!Exists('$(OutputPath)native/CMakeCache.txt')" />
 
     <Exec Command="cmake --build $(OutputPath)native --config $(Configuration)" />
   </Target>

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -1,8 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="ConfigureNative">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+    <DebugType>none</DebugType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDependencyFile>False</GenerateDependencyFile>
   </PropertyGroup>
 
   <Import Project="../Raylib-cs/Build.props" />

--- a/Raylib-cs.Native/Raylib-cs.Native.csproj
+++ b/Raylib-cs.Native/Raylib-cs.Native.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk" InitialTargets="ConfigureNative">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>none</DebugType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/Raylib-cs.Tests/Raylib-cs.Tests.csproj
+++ b/Raylib-cs.Tests/Raylib-cs.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Raylib-cs/Raylib-cs.csproj
+++ b/Raylib-cs/Raylib-cs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <EnableDefaultItems>false</EnableDefaultItems>
     <AssemblyName>Raylib-cs</AssemblyName>
     <RootNamespace>Raylib_cs</RootNamespace>


### PR DESCRIPTION
We don't want to remove old runtimes unless there is a need to do so. This way, we can continue to support projects that don't wish to update their runtime but still enable users that do update their runtime to benefit.

Fixes #295