### PR TITLE
Add STAThread notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ namespace HelloWorld;
 
 class Program
 {
+    // STAThread is required if you deploy using NativeAOT on Windows - See https://github.com/raylib-cs/raylib-cs/issues/301
+    [STAThread]
     public static void Main()
     {
         Raylib.InitWindow(800, 480, "Hello World");


### PR DESCRIPTION
Added notice about deploying for Windows via NativeAOT and the requirement for `STAThread` to the main function to prevent crashes.

See https://github.com/raylib-cs/raylib-cs/issues/301