### PR TITLE
Update structure types to record structs

### DIFF
--- a/Raylib-cs/types/BoundingBox.cs
+++ b/Raylib-cs/types/BoundingBox.cs
@@ -5,7 +5,7 @@ namespace Raylib_cs;
 
 /// <summary>Bounding box type</summary>
 [StructLayout(LayoutKind.Sequential)]
-public partial struct BoundingBox
+public partial record struct BoundingBox
 {
     /// <summary>
     /// Minimum vertex box-corner

--- a/Raylib-cs/types/Camera2D.cs
+++ b/Raylib-cs/types/Camera2D.cs
@@ -7,7 +7,7 @@ namespace Raylib_cs;
 /// Camera2D, defines position/orientation in 2d space
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Camera2D
+public record struct Camera2D
 {
     /// <summary>
     /// Camera offset (displacement from target)

--- a/Raylib-cs/types/Camera3D.cs
+++ b/Raylib-cs/types/Camera3D.cs
@@ -28,7 +28,7 @@ public enum CameraProjection
 /// Camera3D, defines position/orientation in 3d space
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Camera3D
+public record struct Camera3D
 {
     /// <summary>
     /// Camera position

--- a/Raylib-cs/types/Color.cs
+++ b/Raylib-cs/types/Color.cs
@@ -7,7 +7,7 @@ namespace Raylib_cs;
 /// Color type, RGBA (32bit)
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Color
+public record struct Color
 {
     public byte R;
     public byte G;

--- a/Raylib-cs/types/Color.cs
+++ b/Raylib-cs/types/Color.cs
@@ -221,9 +221,4 @@ public record struct Color
     {
         return (byte)(a + (b - a) * t);
     }
-
-    public readonly override string ToString()
-    {
-        return $"{{R:{R} G:{G} B:{B} A:{A}}}";
-    }
 }

--- a/Raylib-cs/types/Ray.cs
+++ b/Raylib-cs/types/Ray.cs
@@ -7,7 +7,7 @@ namespace Raylib_cs;
 /// Ray, ray for raycasting
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Ray
+public record struct Ray
 {
     /// <summary>
     /// Ray position (origin)
@@ -30,7 +30,7 @@ public struct Ray
 /// Raycast hit information
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct RayCollision
+public record struct RayCollision
 {
     /// <summary>
     /// Did the ray hit something?

--- a/Raylib-cs/types/Rectangle.cs
+++ b/Raylib-cs/types/Rectangle.cs
@@ -7,7 +7,7 @@ namespace Raylib_cs;
 /// Rectangle type
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Rectangle
+public record struct Rectangle
 {
     public float X;
     public float Y;

--- a/Raylib-cs/types/Rectangle.cs
+++ b/Raylib-cs/types/Rectangle.cs
@@ -106,9 +106,4 @@ public record struct Rectangle
         Width -= shrink * 2.0f;
         Height -= shrink * 2.0f;
     }
-
-    public readonly override string ToString()
-    {
-        return $"{{X:{X} Y:{Y} Width:{Width} Height:{Height}}}";
-    }
 }

--- a/Raylib-cs/types/Transform.cs
+++ b/Raylib-cs/types/Transform.cs
@@ -7,7 +7,7 @@ namespace Raylib_cs;
 /// Transform, vertex transformation data
 /// </summary>
 [StructLayout(LayoutKind.Sequential)]
-public struct Transform
+public record struct Transform
 {
     /// <summary>
     /// Translation


### PR DESCRIPTION
An extension of a solution to #320 

Update structure types to `record struct` to include built-in [equality operators](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record#value-equality) `==` and `!=`, as well as [display formatting](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/record#built-in-formatting-for-display)